### PR TITLE
Reference all SC CFamily examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   * [Go project analyzed on SonarCloud using Travis](https://github.com/SonarSource/sonarcloud_example_go-sqscanner-travis)
 * **C/C++/Objective-C**
 
-  All SonarCloud Scanner examples for C, C++ and Objective-C can be found [here](https://github.com/sonarsource-cfamily-examples?q=-sc).
+  All SonarCloud Scanner examples for C, C++ and Objective-C can be found [here](https://github.com/orgs/sonarsource-cfamily-examples/repositories?q=-sc&type=all).
 * **Other languages**
   * [Standard SQ-Scanner-based project analyzed on SonarCloud using Travis](https://github.com/SonarSource/sq-com_example_standard-sqscanner-travis)
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,8 @@
 * **Go**
   * [Go project analyzed on SonarCloud using Travis](https://github.com/SonarSource/sonarcloud_example_go-sqscanner-travis)
 * **C/C++/Objective-C**
-  * [C++ GNU Autotools-based project analyzed on SonarCloud using Travis](https://github.com/sonarsource-cfamily-examples/linux-autotools-travis-sc)
-  * [C++ GNU Autotools-based project analyzed on SonarCloud with test coverage using Travis](https://github.com/sonarsource-cfamily-examples/linux-autotools-gcov-travis-sc)
-  * [C++ CMake-based project analyzed on SonarCloud using Travis](https://github.com/sonarsource-cfamily-examples/linux-cmake-travis-sc)
-  * [C SQ-Scanner-based project analyzed on SonarCloud using Travis](https://github.com/SonarSource/sq-com_example_c-sqscanner-travis)
+
+  All SonarCloud Scanner examples for C, C++ and Objective-C can be found [here](https://github.com/sonarsource-cfamily-examples?q=-sc).
 * **Other languages**
   * [Standard SQ-Scanner-based project analyzed on SonarCloud using Travis](https://github.com/SonarSource/sq-com_example_standard-sqscanner-travis)
 


### PR DESCRIPTION
And remove references to individual examples including the no-longer supported example of C on Travis